### PR TITLE
Integration of WebSurf IN Zatoga in a zato.ga subdomain

### DIFF
--- a/app/premium/view.html
+++ b/app/premium/view.html
@@ -39,8 +39,8 @@ let apps = {
     setFrame("https://evgeny-nadymov.github.io/telegram-react/");
   },
   "discord":function(){
-    alert("Please note that you have to log into discord via QR Code. The normal login (email + password) will not work for some reason and may lock your discord account.")
-    setFrame("https://websurfpro.tamoghnak13.repl.co/fetch/aHR0cHM6Ly9kaXNjb3JkLmNvbQ==/login");
+    //alert("Please note that you have to log into discord via QR Code. The normal login (email + password) will not work for some reason and may lock your discord account.")
+    setFrame("https://www.lightguardsystems.com/wp-content/uploads/2018/03/page-under-construction.jpg");
   }
 }
 apps[app]();


### PR DESCRIPTION
So I don't want websurf in a frame, it should be hosted on a subdomain of Zatoga (like websurf.zato.ga) This can be done by configuring the cname records (i will let you know more).

Can you add me as a collaborator to zatoga in replit and on github so I can integrate it?

we can talk in replit chat if you add me as a collaborator on zatoga on replit and github

#### please reply!! @Irom1 @Irom1 